### PR TITLE
store a functional history of exception notices

### DIFF
--- a/src/main/scala/com/foursquare/exceptionator/actions/ExceptionActions.scala
+++ b/src/main/scala/com/foursquare/exceptionator/actions/ExceptionActions.scala
@@ -1,0 +1,13 @@
+// Copyright 2015 Foursquare Labs Inc. All Rights Reserved.
+
+package com.foursquare.exceptionator.actions
+
+import com.foursquare.exceptionator.model.io.Incoming
+
+trait HasExceptionActions {
+  def exceptionActions: ExceptionActions
+}
+
+trait ExceptionActions extends IndexActions {
+  def save(incoming: Incoming): String
+}

--- a/src/main/scala/com/foursquare/exceptionator/actions/HistoryActions.scala
+++ b/src/main/scala/com/foursquare/exceptionator/actions/HistoryActions.scala
@@ -1,0 +1,17 @@
+// Copyright 2015 Foursquare Labs Inc. All Rights Reserved.
+
+package com.foursquare.exceptionator.actions
+
+import com.foursquare.exceptionator.model.io.{BucketId, Incoming}
+import org.bson.types.ObjectId
+
+trait HasHistoryActions {
+  def historyActions: HistoryActions
+}
+
+trait HistoryActions extends IndexActions {
+  // def get(ids: List[ObjectId]): List[Outgoing]
+  def save(exceptionId: String, incoming: Incoming, buckets: Set[BucketId]): ObjectId
+  def addBucket(id: ObjectId, bucketId: BucketId): Unit
+  def removeBucket(id: ObjectId, bucketId: BucketId): Unit
+}

--- a/src/main/scala/com/foursquare/exceptionator/actions/concrete/ConcreteExceptionActions.scala
+++ b/src/main/scala/com/foursquare/exceptionator/actions/concrete/ConcreteExceptionActions.scala
@@ -1,0 +1,43 @@
+// Copyright 2015 Foursquare Labs Inc. All Rights Reserved.
+
+package com.foursquare.exceptionator.actions.concrete
+
+import com.foursquare.exceptionator.actions.{IndexActions, ExceptionActions}
+import com.foursquare.exceptionator.model.ExceptionRecord
+import com.foursquare.exceptionator.model.io.Incoming
+import com.foursquare.exceptionator.util.{Hash, Logger}
+import com.foursquare.rogue.lift.LiftRogue._
+import com.twitter.ostrich.stats.Stats
+import net.liftweb.json._
+import org.joda.time.DateTime
+
+
+class ConcreteExceptionActions extends ExceptionActions with IndexActions with Logger {
+  def ensureIndexes {
+    List(ExceptionRecord).foreach(metaRecord => {
+      metaRecord.mongoIndexList.foreach(i =>
+        metaRecord.ensureIndex(JObject(i.asListMap.map(fld => JField(fld._1, JInt(fld._2.toString.toInt))).toList)))
+    })
+  }
+
+  def save(incoming: Incoming): String = {
+    val btHash = incoming.btHash.getOrElse (Hash.ofString(incoming.bt.mkString("\n")))
+    val time = DateTime.now
+
+    val existing = Stats.time("exceptionActions.save.updateException") {
+      ExceptionRecord.where(_.id eqs btHash).findAndModify(_.lastSeen setTo time).upsertOne()
+    }
+
+    if (!existing.isDefined) {
+      Stats.time("exceptionActions.save.upsertException") {
+        ExceptionRecord.where(_.id eqs btHash)
+          .modify(_.messages setTo incoming.msgs)
+          .modify(_.exceptions setTo incoming.excs)
+          .modify(_.backtrace setTo incoming.bt)
+          .modify(_.firstSeen setTo time).upsertOne()
+      }
+    }
+
+    btHash
+  }
+}

--- a/src/main/scala/com/foursquare/exceptionator/actions/concrete/ConcreteHistoryActions.scala
+++ b/src/main/scala/com/foursquare/exceptionator/actions/concrete/ConcreteHistoryActions.scala
@@ -1,0 +1,55 @@
+// Copyright 2015 Foursquare Labs Inc. All Rights Reserved.
+
+package com.foursquare.exceptionator.actions.concrete
+
+import com.foursquare.exceptionator.actions.{IndexActions, HistoryActions}
+import com.foursquare.exceptionator.model.HistoryRecord
+import com.foursquare.exceptionator.model.io.{BucketId, Incoming}
+import com.foursquare.exceptionator.util.Logger
+import com.foursquare.rogue.lift.LiftRogue._
+import com.twitter.ostrich.stats.Stats
+import net.liftweb.json._
+import org.bson.types.ObjectId
+
+
+class ConcreteHistoryActions extends HistoryActions with IndexActions with Logger {
+  // def get(ids: List[ObjectId]): List[Outgoing] = {
+  //   NoticeRecord.where(_._id in ids).fetch.map(MongoOutgoing(_))
+  // }
+
+  def ensureIndexes {
+    List(HistoryRecord).foreach(metaRecord => {
+      metaRecord.mongoIndexList.foreach(i =>
+        metaRecord.ensureIndex(JObject(i.asListMap.map(fld => JField(fld._1, JInt(fld._2.toString.toInt))).toList)))
+    })
+  }
+
+  def save(exceptionId: String, incoming: Incoming, buckets: Set[BucketId]): ObjectId = {
+    val hr = HistoryRecord.createRecordFrom(incoming)
+      .exception(exceptionId)
+      .buckets(buckets.toList.map(_.toString))
+      .save
+    hr._id.value
+  }
+
+  def addBucket(id: ObjectId, bucketId: BucketId) {
+    Stats.time("incomingActions.addHistoryBucket") {
+      HistoryRecord.where(_._id eqs id).modify(_.buckets push bucketId.toString).updateOne()
+    }
+  }
+
+  def removeBucket(id: ObjectId, bucketId: BucketId) {
+    val result = Stats.time("historyActions.removeBucket") {
+      HistoryRecord.where(_._id eqs id)
+      .select(_.buckets)
+      .findAndModify(_.buckets pull bucketId.toString).updateOne(true)
+    }
+
+    if (result.exists(_.isEmpty)) {
+      logger.debug("deleting " + id.toString)
+      Stats.time("historyActions.removeBucket.deleteRecord") {
+        HistoryRecord.delete("_id", id)
+      }
+    }
+  }
+}

--- a/src/main/scala/com/foursquare/exceptionator/model/ExceptionRecord.scala
+++ b/src/main/scala/com/foursquare/exceptionator/model/ExceptionRecord.scala
@@ -1,0 +1,46 @@
+// Copyright 2015 Foursquare Labs Inc. All Rights Reserved.
+
+package com.foursquare.exceptionator.model
+
+import com.foursquare.exceptionator.model.io.Incoming
+import com.foursquare.index.{Asc, IndexedRecord}
+import com.foursquare.rogue._
+import com.foursquare.rogue.lift.LiftRogue._
+import net.liftweb.mongodb.record.{MongoRecord, MongoMetaRecord}
+import net.liftweb.mongodb.record.field.{DateField, MongoListField, StringPk}
+import net.liftweb.record.field._
+
+/** A record storing the highly redundant exception data from NoticeRecord.notice */
+class ExceptionRecord extends MongoRecord[ExceptionRecord] with StringPk[ExceptionRecord] {
+  def meta = ExceptionRecord
+
+  object messages extends MongoListField[ExceptionRecord, String](this) {
+    override def name = "m"
+  }
+
+  object exceptions extends MongoListField[ExceptionRecord, String](this) {
+    override def name = "e"
+  }
+
+  object backtrace extends MongoListField[ExceptionRecord, String](this) {
+    override def name = "b"
+  }
+
+  object firstSeen extends DateField[ExceptionRecord](this) {
+    override def name = "df"
+  }
+
+  object lastSeen extends DateField[ExceptionRecord](this) {
+    override def name = "dl"
+  }
+}
+
+object ExceptionRecord extends ExceptionRecord
+    with MongoMetaRecord[ExceptionRecord]
+    with IndexedRecord[ExceptionRecord]
+{
+  override def collectionName = "exceptions"
+
+  override val mongoIndexList = List(
+    ExceptionRecord.index(_.id, Asc))
+}

--- a/src/main/scala/com/foursquare/exceptionator/model/HistoryRecord.scala
+++ b/src/main/scala/com/foursquare/exceptionator/model/HistoryRecord.scala
@@ -1,0 +1,73 @@
+// Copyright 2015 Foursquare Labs Inc. All Rights Reserved.
+
+package com.foursquare.exceptionator.model
+
+import com.foursquare.exceptionator.model.io.Incoming
+import com.foursquare.index.{Asc, IndexedRecord}
+import com.foursquare.rogue._
+import com.foursquare.rogue.lift.LiftRogue._
+import java.util.Date
+import net.liftweb.mongodb.record.{MongoRecord, MongoMetaRecord, MongoId}
+import net.liftweb.mongodb.record.field.{MongoListField, MongoMapField, ObjectIdField, DateField}
+import net.liftweb.record.field._
+import org.bson.types.ObjectId
+
+
+/** A stripped down notice to be stored for history lookup. */
+class HistoryRecord extends MongoRecord[HistoryRecord] with MongoId[HistoryRecord] {
+  def meta = HistoryRecord
+
+  object exception extends StringField[HistoryRecord](this, 32) {
+    override def name = "e"
+  }
+
+  object buckets extends MongoListField[HistoryRecord, String](this) {
+    override def name = "b"
+  }
+
+  object environment extends MongoMapField[HistoryRecord, String](this) {
+    override def name = "en"
+  }
+
+  object host extends StringField[HistoryRecord](this, 50) {
+    override def name = "h"
+  }
+
+  object version extends StringField[HistoryRecord](this, 50) {
+    override def name = "v"
+  }
+
+  object counted extends IntField[HistoryRecord](this) {
+    override def name = "c"
+    override def optional_? = true
+  }
+
+  object date extends DateField[HistoryRecord](this) {
+    override def name = "d"
+    override def optional_? = true
+  }
+
+}
+
+object HistoryRecord extends HistoryRecord
+    with MongoMetaRecord[HistoryRecord]
+    with IndexedRecord[HistoryRecord]
+{
+  override def collectionName = "history"
+
+  override val mongoIndexList = List(
+    HistoryRecord.index(_._id, Asc))
+
+  def createRecordFrom(incoming: Incoming): HistoryRecord = {
+    val rec = createRecord
+    rec.environment(incoming.env)
+    rec.host(incoming.h)
+    rec.version(incoming.v)
+    rec.counted(incoming.n)
+    incoming.d.foreach(epoch => {
+      rec._id(new ObjectId(new Date(epoch)))
+      rec.date(new Date(epoch))
+    })
+    rec
+  }
+}

--- a/src/main/scala/com/foursquare/exceptionator/model/io/Incoming.scala
+++ b/src/main/scala/com/foursquare/exceptionator/model/io/Incoming.scala
@@ -19,8 +19,9 @@ case class BacktraceLine(method: String, fileName: String, number:Int) {
 
 case class Incoming (
   msgs: List[String], // messages
-  excs: List[String], // exception classes 
+  excs: List[String], // exception classes
   bt: List[String], // exception stack
+  btHash: Option[String], // exception stack (joined with newlines) md5 hash
   sess: Map[String, String], // session
   env: Map[String, String], // environment
   h: String, // host
@@ -30,10 +31,10 @@ case class Incoming (
   tags: Option[List[String]]
 ) {
   def structuredBacktrace: List[List[BacktraceLine]] = bt.map(_.split("\n").map(BacktraceLine(_)).toList)
-  
+
   // TODO: replace these with something more modular
   def flatBacktrace = bt.flatMap(_.split("\n").toList)
-  def firstInteresting: Option[BacktraceLine] = 
+  def firstInteresting: Option[BacktraceLine] =
     flatBacktrace.find(l => isInteresting(l)).map(l => BacktraceLine(l))
   def firstNInteresting(n: Int): List[BacktraceLine] =
     flatBacktrace.filter(l => isInteresting(l)).slice(0,n).map(l => BacktraceLine(l))

--- a/src/main/scala/com/foursquare/exceptionator/service/IncomingService.scala
+++ b/src/main/scala/com/foursquare/exceptionator/service/IncomingService.scala
@@ -40,7 +40,7 @@ class IncomingHttpService(incomingActions: IncomingActions, backgroundActions: B
               response.contentString = res.mkString(",")
               response
             })
-          case _ => 
+          case _ =>
             ServiceUtil.errorResponse(HttpResponseStatus.NOT_FOUND)
         }
 
@@ -49,7 +49,7 @@ class IncomingHttpService(incomingActions: IncomingActions, backgroundActions: B
     }
   }
 
-  def process(incoming: Incoming) = { 
+  def process(incoming: Incoming) = {
     incomingLog.foreach(log => {
       log.write(generate(incoming))
       log.write("\n")


### PR DESCRIPTION
With this commit, exceptionator will store data on notices it
receives indefinitely (recommend a capped collection) to support
the upcoming history view.

Rather than reusing NoticeRecords, which can be rather large, this
commit creates two new models:
- HistoryRecord, a stripped down version of a NoticeRecord
- ExceptionRecord, which provides separate storage for large and
    highly redundant stack information

Corresponding ExceptionActions and HistoryActions are also added for
handling these datatypes.
