### PR TITLE
Add support for a sampled history

### DIFF
--- a/config.json
+++ b/config.json
@@ -40,6 +40,11 @@
 
   },
 
+  "history": {
+    "flushPeriod": 60,
+    "sampleRate": 200
+  },
+
   "rollingRank": {
     "tokenizers": "(?:\\s|[=?&./,:\"{}$\\-\\(\\)\\[\\]]|%[0-9A-Fa-f][0-9A-Fa-f])+",
     "filterNot": "\\d{1,4}|^\\W*$"
@@ -52,7 +57,7 @@
       ],
       "filterNot": [
         "^com.foursquare.rogue",
-        "^com.foursquare.slashem",         
+        "^com.foursquare.slashem",
         "^com.foursquare.boot.MongoSetup\\$FSQueryValidator"
       ]
     }

--- a/config.json
+++ b/config.json
@@ -42,8 +42,8 @@
 
   "history": {
     "flushPeriod": 60,
-    "sampleRate": 200,
-    "sampleWindowSeconds": 15
+    "sampleRate": 50,
+    "sampleWindowSeconds": 60
   },
 
   "rollingRank": {

--- a/config.json
+++ b/config.json
@@ -42,7 +42,8 @@
 
   "history": {
     "flushPeriod": 60,
-    "sampleRate": 200
+    "sampleRate": 200,
+    "sampleWindowSeconds": 15
   },
 
   "rollingRank": {

--- a/dumper.py
+++ b/dumper.py
@@ -1,0 +1,37 @@
+from BaseHTTPServer import BaseHTTPRequestHandler
+import json
+import optparse
+import SocketServer
+import sys
+
+
+class JsonDumpHandler(BaseHTTPRequestHandler):
+  def do_POST(self):
+    content_len = int(self.headers.getheader('content-length', 0))
+    raw = self.rfile.read(content_len)
+
+    if self.path == '/api/notice':
+      sys.stdout.write(raw)
+    elif self.path == '/api/multi-notice':
+      try:
+        for notice in json.loads(raw):
+          json.dump(notice, sys.stdout)
+          sys.stdout.write('\n')
+      except Exception:
+        pass
+
+    sys.stdout.flush()
+    self.send_response(200)
+
+
+if __name__ == '__main__':
+  parser = optparse.OptionParser('usage: %s [options]' % sys.argv[0])
+  parser.add_option('--port', dest='port', help='listen on port PORT')
+  (options, args) = parser.parse_args(args=sys.argv)
+
+  port = 8080
+  if options.port:
+    port = int(options.port)
+
+  httpd = SocketServer.TCPServer(("localhost", port), JsonDumpHandler)
+  httpd.serve_forever()

--- a/src/main/resources/content/exceptionator.backbone.js
+++ b/src/main/resources/content/exceptionator.backbone.js
@@ -269,22 +269,30 @@ Exceptionator.NoticeListView = Backbone.View.extend({
 
   events: {
     "click .exc_header": "toggleBody",
-    "click .bucketLink": "handleLinkClick"
+    "click .bucketLink": "handleLinkClick",
+    "plotclick": "handlePlotClick"
   },
 
   toggleBody: function(e) {
     $(e.target).parents('.exc').toggleClass('exc_hidden');
   },
 
-  handleLinkClick: function(e) {
+  handleClick: function(e, url) {
     // neat trick from http://dev.tenfarms.com/posts/proper-link-handling
     if (!e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
       e.preventDefault();
-      var url = $(e.target).attr("href").replace(/^\//, "");
       Exceptionator.Router.navigate(url, { trigger: true });
     } else {
       e.stopPropagation();
     }
+  },
+
+  handleLinkClick: function(e) {
+    this.handleClick(e, $(e.target).attr("href").replace(/^\//, ""));
+  },
+
+  handlePlotClick: function (e, pos, item) {
+    this.handleClick(e, "/history/" + Math.floor(pos.x));
   },
 
   getTitleEl: function() {
@@ -381,7 +389,8 @@ Exceptionator.NoticeListView = Backbone.View.extend({
       var options = {
         lines: { show: true },
         legend: { position: "nw" },
-        xaxis: { mode: "time", timezone: "browser" }
+        xaxis: { mode: "time", timezone: "browser" },
+        grid: { clickable: true }
       };
       var histograms = _.first(this.collection.histograms(), Exceptionator.NoticeListView.MAX_GRAPH_LINES);
 

--- a/src/main/resources/content/exceptionator.backbone.js
+++ b/src/main/resources/content/exceptionator.backbone.js
@@ -9,6 +9,7 @@ Exceptionator.GraphSpans = {
 Exceptionator.ListTypes = {
   BUCKET_KEY: 'bucket_key',
   BUCKET_GROUP: 'bucket_group',
+  HISTORY: 'history',
   SEARCH: 'search'
 }
 
@@ -87,7 +88,8 @@ Exceptionator.Notice = Backbone.Model.extend({
       this.get('bt')[index] = backtrace.split('\n');
     }, this);
   },
-  histogram: function(bucket) {
+
+  histogram: function(histogramMap) {
     var fieldName;
     if (Exceptionator.GraphSpan == Exceptionator.GraphSpans.LAST_HOUR) {
       fieldName = 'h';
@@ -98,18 +100,17 @@ Exceptionator.Notice = Backbone.Model.extend({
     if (Exceptionator.GraphSpan == Exceptionator.GraphSpans.LAST_MONTH) {
       fieldName = 'm';
     }
-    return this.get('bkts')[bucket]['h'][fieldName];
+    return histogramMap[fieldName];
   }
 },{
 
-  emptyHistogram: function() {
-    var dateNow = new Date()
-    var stop = dateNow.getTime();
-    stop -= dateNow.getUTCMilliseconds();
-    stop -= dateNow.getUTCSeconds() * 1000;
+  emptyHistogram: function(endDate) {
+    var stop = endDate.getTime();
+    stop -= endDate.getUTCMilliseconds();
+    stop -= endDate.getUTCSeconds() * 1000;
 
-    dateNow.setMilliseconds(0)
-    dateNow.setSeconds(0);
+    endDate.setMilliseconds(0)
+    endDate.setSeconds(0);
 
     var step;
     var nSteps;
@@ -118,13 +119,13 @@ Exceptionator.Notice = Backbone.Model.extend({
       nSteps = 60;
     }
     if (Exceptionator.GraphSpan == Exceptionator.GraphSpans.LAST_DAY) {
-      stop -= dateNow.getUTCMinutes() * 60 * 1000;
+      stop -= endDate.getUTCMinutes() * 60 * 1000;
       step = 60 * 60 * 1000;
       nSteps = 24;
     }
     if (Exceptionator.GraphSpan == Exceptionator.GraphSpans.LAST_MONTH) {
-      stop -= dateNow.getUTCMinutes() * 60 * 1000;
-      stop -= dateNow.getUTCHours() * 60 * 60 * 1000;
+      stop -= endDate.getUTCMinutes() * 60 * 1000;
+      stop -= endDate.getUTCHours() * 60 * 60 * 1000;
       step = 24 * 60 * 60 * 1000;
       nSteps = 30;
     }
@@ -171,7 +172,14 @@ Exceptionator.NoticeList = Backbone.Collection.extend({
   model: Exceptionator.Notice,
 
   initialize: function(models, options) {
-    if (options.bucketName && options.bucketKey) {
+    if (options.timestamp) {
+      this.listType = Exceptionator.ListTypes.HISTORY;
+      this.timestamp = Number(options.timestamp);
+      this.timeOffset = Date.now() - this.timestamp;
+      this.id = 'history_' + this.timestamp;
+      this.title = 'history: ' + this.timestamp;
+
+    } else if (options.bucketName && options.bucketKey) {
       this.listType = Exceptionator.ListTypes.BUCKET_KEY;
       this.bucketKey = options.bucketKey;
       this.bucketName = options.bucketName;
@@ -183,6 +191,7 @@ Exceptionator.NoticeList = Backbone.Collection.extend({
         this.title = this.bucketName;
       }
       this.title += ': ' + this.bucketKey;
+
     } else if (options.bucketName) {
       this.listType = Exceptionator.ListTypes.BUCKET_GROUP;
       this.bucketName = options.bucketName;
@@ -193,6 +202,7 @@ Exceptionator.NoticeList = Backbone.Collection.extend({
       } else {
         this.title = this.bucketName;
       }
+
     } else {
       this.query = options.query;
       this.listType = Exceptionator.ListTypes.SEARCH;
@@ -203,7 +213,11 @@ Exceptionator.NoticeList = Backbone.Collection.extend({
   },
 
   url: function() {
-    return this.urlPart + 'limit=' + encodeURIComponent(Exceptionator.Limit);
+    if (this.listType == Exceptionator.ListTypes.HISTORY) {
+      return '/api/history/' + (Date.now()-this.timeOffset) + '?limit=' + encodeURIComponent(Exceptionator.Limit);
+    } else {
+      return this.urlPart + 'limit=' + encodeURIComponent(Exceptionator.Limit);
+    }
   },
 
   timeReverseSorted: function() {
@@ -211,19 +225,22 @@ Exceptionator.NoticeList = Backbone.Collection.extend({
   },
 
   histograms: function() {
-    var empty = Exceptionator.Notice.emptyHistogram();
+    var empty = Exceptionator.Notice.emptyHistogram(new Date());
     var seriesList = [];
-    if (this.listType == Exceptionator.ListTypes.BUCKET_KEY) {
-      var mostRecent =  this.min(Exceptionator.NoticeList.reverseTimeIterator_);
-      if (mostRecent) {
-        seriesList = [{label: '', values: mostRecent.histogram(this.bucketName)}];
-      }
-    }
 
-    if (this.listType == Exceptionator.ListTypes.BUCKET_GROUP) {
+    if (this.listType == Exceptionator.ListTypes.BUCKET_KEY) {
+      var mostRecent = this.min(Exceptionator.NoticeList.reverseTimeIterator_);
+      if (mostRecent) {
+        seriesList = [{label: '', values: mostRecent.histogram(mostRecent.get('bkts')[this.bucketName]['h'])}];
+      }
+    } else if (this.listType == Exceptionator.ListTypes.BUCKET_GROUP) {
       seriesList = _.map(this.timeReverseSorted(), function(model) {
-        return {label: model.get('bkts')[this.bucketName]['k'], values: model.histogram(this.bucketName)};
+        return {label: model.get('bkts')[this.bucketName]['k'], values: model.histogram(model.get('bkts')[this.bucketName]['h'])};
       }, this);
+    } else if (this.listType == Exceptionator.ListTypes.HISTORY) {
+      empty = Exceptionator.Notice.emptyHistogram(new Date(Date.now() - this.timeOffset));
+      var mostRecent = this.min(Exceptionator.NoticeList.reverseTimeIterator_);
+      var seriesList = [{label: '', values: mostRecent.histogram(mostRecent.get('hist'))}];
     }
 
     var retval = [];
@@ -671,7 +688,8 @@ Exceptionator.Routing = Backbone.Router.extend({
     "notices/:bucketName":            "bucketGroup",
     "filters":                        "filters",
     "filters/":                       "filters",
-    "filters/:filterId":              "filters"
+    "filters/:filterId":              "filters",
+    "history/:timestamp":             "history"
   },
 
   route_: function(listDefs) {
@@ -724,5 +742,9 @@ Exceptionator.Routing = Backbone.Router.extend({
 
   bucketGroup: function(bucketName) {
     this.route_([{list: {bucketName: decodeURIComponent(bucketName)}}]);
+  },
+
+  history: function(timestamp) {
+    this.route_([{list: {timestamp: timestamp}}])
   }
 });

--- a/src/main/scala/com/foursquare/exceptionator/actions/HistoryActions.scala
+++ b/src/main/scala/com/foursquare/exceptionator/actions/HistoryActions.scala
@@ -1,0 +1,15 @@
+// Copyright 2015 Foursquare Labs Inc. All Rights Reserved.
+
+package com.foursquare.exceptionator.actions
+
+import com.foursquare.exceptionator.model.NoticeRecord
+import java.util.Date
+
+
+trait HasHistoryActions {
+  def historyActions: HistoryActions
+}
+
+trait HistoryActions extends IndexActions {
+  def save(notice: NoticeRecord): Date
+}

--- a/src/main/scala/com/foursquare/exceptionator/actions/HistoryActions.scala
+++ b/src/main/scala/com/foursquare/exceptionator/actions/HistoryActions.scala
@@ -3,7 +3,8 @@
 package com.foursquare.exceptionator.actions
 
 import com.foursquare.exceptionator.model.NoticeRecord
-import java.util.Date
+import com.foursquare.exceptionator.model.io.Outgoing
+import org.joda.time.DateTime
 
 
 trait HasHistoryActions {
@@ -11,5 +12,6 @@ trait HasHistoryActions {
 }
 
 trait HistoryActions extends IndexActions {
-  def save(notice: NoticeRecord): Date
+  def get(time: DateTime, limit: Int): List[Outgoing]
+  def save(notice: NoticeRecord): DateTime
 }

--- a/src/main/scala/com/foursquare/exceptionator/actions/NoticeActions.scala
+++ b/src/main/scala/com/foursquare/exceptionator/actions/NoticeActions.scala
@@ -2,6 +2,7 @@
 
 package com.foursquare.exceptionator.actions
 
+import com.foursquare.exceptionator.model.NoticeRecord
 import com.foursquare.exceptionator.model.io.{BucketId, Incoming, Outgoing}
 import org.bson.types.ObjectId
 
@@ -12,7 +13,7 @@ trait HasNoticeActions {
 trait NoticeActions extends IndexActions {
   def get(ids: List[ObjectId]): List[Outgoing]
   def search(keywords: List[String], limit: Option[Int]): List[Outgoing]
-  def save(incoming: Incoming, tags: Set[String], keywords: Set[String], buckets: Set[BucketId]): ObjectId
+  def save(incoming: Incoming, tags: Set[String], keywords: Set[String], buckets: Set[BucketId]): NoticeRecord
   def addBucket(id: ObjectId, bucketId: BucketId): Unit
   def removeBucket(id: ObjectId, bucketId: BucketId): Unit
 }

--- a/src/main/scala/com/foursquare/exceptionator/actions/concrete/ConcreteHistoryActions.scala
+++ b/src/main/scala/com/foursquare/exceptionator/actions/concrete/ConcreteHistoryActions.scala
@@ -3,24 +3,24 @@
 package com.foursquare.exceptionator.actions.concrete
 
 import com.foursquare.exceptionator.actions.{HistoryActions, IndexActions}
-import com.foursquare.exceptionator.model.{HistoryRecord, NoticeRecord}
+import com.foursquare.exceptionator.model.{HistoryRecord, MongoOutgoing, NoticeRecord}
+import com.foursquare.exceptionator.model.io.Outgoing
 import com.foursquare.exceptionator.util.{Config, Logger, ReservoirSampler}
 import com.foursquare.rogue.lift.LiftRogue._
-import com.twitter.ostrich.stats.Stats
-import java.util.Date
-import java.util.concurrent.ConcurrentHashMap
-import net.liftweb.json.{JField, JInt, JObject}
-import scala.collection.JavaConverters.mapAsScalaConcurrentMapConverter
-import scala.util.Random
 import com.twitter.conversions.time._
 import com.twitter.ostrich.stats.Stats
 import com.twitter.util.ScheduledThreadPoolTimer
+import java.util.concurrent.ConcurrentHashMap
+import net.liftweb.json.{JField, JInt, JObject}
+import org.joda.time.DateTime
+import scala.collection.JavaConverters.mapAsScalaConcurrentMapConverter
+import scala.util.Random
 
 
 class ConcreteHistoryActions extends HistoryActions with IndexActions with Logger {
   val flushPeriod = Config.opt(_.getInt("history.flushPeriod")).getOrElse(60)
   val sampleRate = Config.opt(_.getInt("history.sampleRate")).getOrElse(50)
-  val samplers = (new ConcurrentHashMap[Date, ReservoirSampler[NoticeRecord]]).asScala
+  val samplers = (new ConcurrentHashMap[DateTime, ReservoirSampler[NoticeRecord]]).asScala
   val timer = new ScheduledThreadPoolTimer(makeDaemons=true)
 
   timer.schedule(flushPeriod seconds, flushPeriod seconds) {
@@ -55,15 +55,17 @@ class ConcreteHistoryActions extends HistoryActions with IndexActions with Logge
             val existingSampler = ReservoirSampler(existing.sampleRate.value, existingState)
             val merged = ReservoirSampler.merge(existingSampler, sampler)
             val state = merged.state
-            existing.notices(state.samples.toList).totalSampled(state.sampled).save
+            val sorted = state.samples.sortBy(_._id.value).reverse
+            existing.notices(sorted.toList).totalSampled(state.sampled).save
           }
         }).getOrElse {
           logger.debug(s"Writing new history for ${historyId}")
           Stats.time("historyActions.flushNew") {
             val state = sampler.state
+            val sorted = state.samples.sortBy(_._id.value).reverse
             HistoryRecord.createRecord
               .id(historyId)
-              .notices(state.samples.toList)
+              .notices(sorted.toList)
               .sampleRate(sampleRate)
               .totalSampled(state.sampled)
               .save
@@ -72,13 +74,27 @@ class ConcreteHistoryActions extends HistoryActions with IndexActions with Logge
     }
   }
 
+  def get(time: DateTime, limit: Int): List[Outgoing] = {
+    val historyId = HistoryRecord.idForTime(time)
+    val historyOpt = HistoryRecord.where(_.id lte historyId).orderDesc(_.id).get()
+    historyOpt.map { history =>
+      val outgoing = history.notices.value.dropWhile(_.createDateTime.isAfter(time)).take(limit).map(MongoOutgoing(_).addHistorygrams())
+      if (outgoing.size < limit) {
+        // recurse and look at previous records to flush out our list
+        outgoing ++ get(history.id.dateTimeValue.minusMillis(1), limit - outgoing.size)
+      } else {
+        outgoing
+      }
+    }.getOrElse(Nil)
+  }
+
   // Save a notice to its HistoryRecord, using reservoir sampling
-  def save(notice: NoticeRecord): Date = {
-    val historyId = HistoryRecord.idForTime(notice.createTime)
-    Stats.time("historyActions.updateSampler") {
-      val sampler = samplers.getOrElseUpdate(historyId, new ReservoirSampler[NoticeRecord](sampleRate))
-      sampler.update(notice)
-    }
+  def save(notice: NoticeRecord): DateTime = {
+    // use the client-provided date if available, otherwise record creation time
+    val dateTime = notice.notice.value.d.map(new DateTime(_)).getOrElse(notice.createDateTime)
+    val historyId = HistoryRecord.idForTime(dateTime)
+    val sampler = samplers.getOrElseUpdate(historyId, new ReservoirSampler[NoticeRecord](sampleRate))
+    sampler.update(notice)
     historyId
   }
 }

--- a/src/main/scala/com/foursquare/exceptionator/actions/concrete/ConcreteHistoryActions.scala
+++ b/src/main/scala/com/foursquare/exceptionator/actions/concrete/ConcreteHistoryActions.scala
@@ -1,0 +1,84 @@
+// Copyright 2015 Foursquare Labs Inc. All Rights Reserved.
+
+package com.foursquare.exceptionator.actions.concrete
+
+import com.foursquare.exceptionator.actions.{HistoryActions, IndexActions}
+import com.foursquare.exceptionator.model.{HistoryRecord, NoticeRecord}
+import com.foursquare.exceptionator.util.{Config, Logger, ReservoirSampler}
+import com.foursquare.rogue.lift.LiftRogue._
+import com.twitter.ostrich.stats.Stats
+import java.util.Date
+import java.util.concurrent.ConcurrentHashMap
+import net.liftweb.json.{JField, JInt, JObject}
+import scala.collection.JavaConverters.mapAsScalaConcurrentMapConverter
+import scala.util.Random
+import com.twitter.conversions.time._
+import com.twitter.ostrich.stats.Stats
+import com.twitter.util.ScheduledThreadPoolTimer
+
+
+class ConcreteHistoryActions extends HistoryActions with IndexActions with Logger {
+  val flushPeriod = Config.opt(_.getInt("history.flushPeriod")).getOrElse(60)
+  val sampleRate = Config.opt(_.getInt("history.sampleRate")).getOrElse(50)
+  val samplers = (new ConcurrentHashMap[Date, ReservoirSampler[NoticeRecord]]).asScala
+  val timer = new ScheduledThreadPoolTimer(makeDaemons=true)
+
+  timer.schedule(flushPeriod seconds, flushPeriod seconds) {
+    try {
+      Stats.time("historyActions.flushHistory") {
+        flushHistory()
+      }
+    } catch {
+      case t: Throwable => logger.debug("Error flushing history", t)
+    }
+  }
+
+  def ensureIndexes {
+    List(HistoryRecord).foreach(metaRecord => {
+      metaRecord.mongoIndexList.foreach(i =>
+        metaRecord.ensureIndex(JObject(i.asListMap.map(fld => JField(fld._1, JInt(fld._2.toString.toInt))).toList)))
+    })
+  }
+
+  // Write history to mongo
+  def flushHistory(): Unit = {
+    for {
+      historyId <- samplers.keys
+      sampler <- samplers.remove(historyId)
+    } {
+      HistoryRecord.where(_.id eqs historyId).get()
+        .filter(_.sampleRate.value == sampler.size)
+        .map(existing => {
+          logger.debug(s"Merging histories for ${historyId}")
+          Stats.time("historyActions.flushMerge") {
+            val existingState = ReservoirSampler.State(existing.notices.value, existing.totalSampled.value)
+            val existingSampler = ReservoirSampler(existing.sampleRate.value, existingState)
+            val merged = ReservoirSampler.merge(existingSampler, sampler)
+            val state = merged.state
+            existing.notices(state.samples.toList).totalSampled(state.sampled).save
+          }
+        }).getOrElse {
+          logger.debug(s"Writing new history for ${historyId}")
+          Stats.time("historyActions.flushNew") {
+            val state = sampler.state
+            HistoryRecord.createRecord
+              .id(historyId)
+              .notices(state.samples.toList)
+              .sampleRate(sampleRate)
+              .totalSampled(state.sampled)
+              .save
+          }
+        }
+    }
+  }
+
+  // Save a notice to its HistoryRecord, using reservoir sampling
+  def save(notice: NoticeRecord): Date = {
+    val historyId = HistoryRecord.idForTime(notice.createTime)
+    Stats.time("historyActions.updateSampler") {
+      val sampler = samplers.getOrElseUpdate(historyId, new ReservoirSampler[NoticeRecord](sampleRate))
+      sampler.update(notice)
+    }
+    historyId
+  }
+}

--- a/src/main/scala/com/foursquare/exceptionator/actions/concrete/ConcreteNoticeActions.scala
+++ b/src/main/scala/com/foursquare/exceptionator/actions/concrete/ConcreteNoticeActions.scala
@@ -29,18 +29,12 @@ class ConcreteNoticeActions extends NoticeActions with IndexActions with Logger 
     })
   }
 
-  def save(
-      incoming: Incoming,
-      tags: Set[String],
-      keywords: Set[String],
-      buckets: Set[BucketId]): ObjectId = {
-
-    val nr = NoticeRecord.createRecordFrom(incoming)
+  def save(incoming: Incoming, tags: Set[String], keywords: Set[String], buckets: Set[BucketId]): NoticeRecord = {
+    NoticeRecord.createRecordFrom(incoming)
       .keywords(keywords.toList)
       .tags(tags.toList)
       .buckets(buckets.toList.map(_.toString))
       .save
-    nr._id.value
   }
 
   def addBucket(id: ObjectId, bucketId: BucketId) {

--- a/src/main/scala/com/foursquare/exceptionator/model/HistoryRecord.scala
+++ b/src/main/scala/com/foursquare/exceptionator/model/HistoryRecord.scala
@@ -1,0 +1,62 @@
+// Copyright 2015 Foursquare Labs Inc. All Rights Reserved.
+
+package com.foursquare.exceptionator.model
+
+import com.foursquare.exceptionator.model.io.Incoming
+import net.liftweb.common.{Box, Full}
+import net.liftweb.mongodb.record.{MongoRecord, MongoMetaRecord}
+import net.liftweb.mongodb.record.field.{DateField, MongoListField}
+import net.liftweb.record.field._
+import com.foursquare.rogue._
+import com.foursquare.index.{Asc, IndexedRecord}
+import com.foursquare.rogue.lift.LiftRogue._
+import com.mongodb.{BasicDBList, DBObject}
+import java.util.Date
+
+
+/** Stores one minute of sampled history. Uses the starting timestamp as its _id. */
+class HistoryRecord extends MongoRecord[HistoryRecord] {
+  def meta = HistoryRecord
+
+  object id extends DateField[HistoryRecord](this) {
+    override def name = "_id"
+  }
+
+  // TODO(jacob): must subclass this before it will work, see http://liftweb.net/api/26/api/index.html#net.liftweb.mongodb.record.field.MongoListField
+  object notices extends MongoListField[HistoryRecord, NoticeRecord](this) {
+    override def name = "n"
+
+    override def asDBObject: DBObject = this.synchronized {
+      val dbl = new BasicDBList
+      value.foreach(v => dbl.add(v.asDBObject))
+      dbl
+    }
+
+    override def setFromDBObject(dbo: DBObject): Box[MyType] = {
+      setBox(Full(dbo match {
+        case list: BasicDBList => {
+          (for (i <- 0 to list.size-1) yield (NoticeRecord.fromDBObject(list.get(i).asInstanceOf[DBObject]))).toList
+        }
+        case _ => Nil
+      }))
+    }
+  }
+
+  object sampleRate extends IntField(this) {
+    override def name = "r"
+  }
+
+  object totalSampled extends IntField(this) {
+    override def name = "s"
+  }
+}
+
+object HistoryRecord extends HistoryRecord with MongoMetaRecord[HistoryRecord] with IndexedRecord[HistoryRecord] {
+  override def collectionName = "history"
+
+  // Round down a date to the nearest minute
+  def idForTime(date: Date): Date = new Date((date.getTime / 60000) * 60000)
+
+  override val mongoIndexList = List(
+    HistoryRecord.index(_.id, Asc))
+}

--- a/src/main/scala/com/foursquare/exceptionator/model/HistoryRecord.scala
+++ b/src/main/scala/com/foursquare/exceptionator/model/HistoryRecord.scala
@@ -10,7 +10,7 @@ import com.foursquare.rogue.lift.LiftRogue._
 import com.mongodb.{BasicDBList, DBObject}
 import net.liftweb.common.{Box, Full}
 import net.liftweb.mongodb.record.{MongoRecord, MongoMetaRecord}
-import net.liftweb.mongodb.record.field.{DateField, MongoListField}
+import net.liftweb.mongodb.record.field.{BsonRecordListField, DateField}
 import net.liftweb.record.field._
 import org.joda.time.DateTime
 
@@ -25,24 +25,8 @@ class HistoryRecord extends MongoRecord[HistoryRecord] {
     def dateTimeValue: DateTime = new DateTime(value)
   }
 
-  // TODO(jacob): must subclass this before it will work, see http://liftweb.net/api/26/api/index.html#net.liftweb.mongodb.record.field.MongoListField
-  object notices extends MongoListField[HistoryRecord, NoticeRecord](this) {
+  object notices extends BsonRecordListField[HistoryRecord, NoticeRecord](this, NoticeRecord) {
     override def name = "n"
-
-    override def asDBObject: DBObject = this.synchronized {
-      val dbl = new BasicDBList
-      value.foreach(v => dbl.add(v.asDBObject))
-      dbl
-    }
-
-    override def setFromDBObject(dbo: DBObject): Box[MyType] = {
-      setBox(Full(dbo match {
-        case list: BasicDBList => {
-          (for (i <- 0 to list.size-1) yield (NoticeRecord.fromDBObject(list.get(i).asInstanceOf[DBObject]))).toList
-        }
-        case _ => Nil
-      }))
-    }
   }
 
   object sampleRate extends IntField(this) {

--- a/src/main/scala/com/foursquare/exceptionator/model/NoticeRecord.scala
+++ b/src/main/scala/com/foursquare/exceptionator/model/NoticeRecord.scala
@@ -18,7 +18,8 @@ import java.util.Date
 class NoticeRecord extends MongoRecord[NoticeRecord] with MongoId[NoticeRecord] {
   def meta = NoticeRecord
 
-  def createTime = new DateTime(id.getTime(), DateTimeZone.UTC).toDate
+  def createDateTime = new DateTime(id.getTime(), DateTimeZone.UTC)
+  def createTime = createDateTime.toDate
 
   object notice extends MongoCaseClassField[NoticeRecord, Incoming](this) {
     override def name = "n"

--- a/src/main/scala/com/foursquare/exceptionator/model/io/Incoming.scala
+++ b/src/main/scala/com/foursquare/exceptionator/model/io/Incoming.scala
@@ -19,7 +19,7 @@ case class BacktraceLine(method: String, fileName: String, number:Int) {
 
 case class Incoming (
   msgs: List[String], // messages
-  excs: List[String], // exception classes 
+  excs: List[String], // exception classes
   bt: List[String], // exception stack
   sess: Map[String, String], // session
   env: Map[String, String], // environment
@@ -27,13 +27,14 @@ case class Incoming (
   v: String, // version
   n: Option[Int], // count
   d: Option[Long], //date
-  tags: Option[List[String]]
+  tags: Option[List[String]],
+  id: Int
 ) {
   def structuredBacktrace: List[List[BacktraceLine]] = bt.map(_.split("\n").map(BacktraceLine(_)).toList)
-  
+
   // TODO: replace these with something more modular
   def flatBacktrace = bt.flatMap(_.split("\n").toList)
-  def firstInteresting: Option[BacktraceLine] = 
+  def firstInteresting: Option[BacktraceLine] =
     flatBacktrace.find(l => isInteresting(l)).map(l => BacktraceLine(l))
   def firstNInteresting(n: Int): List[BacktraceLine] =
     flatBacktrace.filter(l => isInteresting(l)).slice(0,n).map(l => BacktraceLine(l))

--- a/src/main/scala/com/foursquare/exceptionator/service/ExceptionatorService.scala
+++ b/src/main/scala/com/foursquare/exceptionator/service/ExceptionatorService.scala
@@ -4,11 +4,13 @@ package com.foursquare.exceptionator.service
 
 import com.codahale.jerkson.Json.{parse, stream}
 import com.foursquare.exceptionator.actions.IndexActions
-import com.foursquare.exceptionator.actions.{HasNoticeActions, HasBucketActions, HasUserFilterActions}
+import com.foursquare.exceptionator.actions.{HasBucketActions, HasHistoryActions, HasNoticeActions,
+    HasUserFilterActions}
 import com.foursquare.exceptionator.loader.service.HasPluginLoaderService
 import com.foursquare.exceptionator.loader.concrete.ConcretePluginLoaderService
 import com.foursquare.exceptionator.actions.concrete.{ConcreteBackgroundActions, ConcreteBucketActions,
-  ConcreteIncomingActions, ConcreteNoticeActions, ConcreteUserFilterActions, FilteredConcreteIncomingActions}
+    ConcreteHistoryActions, ConcreteIncomingActions, ConcreteNoticeActions, ConcreteUserFilterActions,
+    FilteredConcreteIncomingActions}
 import com.foursquare.exceptionator.util.{Config, Logger, ConcreteMailSender, ConcreteBlamer}
 import com.mongodb.{MongoClient, DBAddress, MongoException, MongoClientOptions, ServerAddress}
 import com.twitter.finagle.builder.{ServerBuilder, Server}
@@ -134,13 +136,15 @@ object ExceptionatorServer extends Logger {
     Config.defaultInit()
 
     val services = new HasBucketActions
+        with HasHistoryActions
         with HasNoticeActions
-        with HasUserFilterActions
-        with HasPluginLoaderService {
-      lazy val noticeActions = new ConcreteNoticeActions
+        with HasPluginLoaderService
+        with HasUserFilterActions {
       lazy val bucketActions = new ConcreteBucketActions
-      lazy val userFilterActions = new ConcreteUserFilterActions
+      lazy val historyActions = new ConcreteHistoryActions
+      lazy val noticeActions = new ConcreteNoticeActions
       lazy val pluginLoader = new ConcretePluginLoaderService(this)
+      lazy val userFilterActions = new ConcreteUserFilterActions
     }
 
     // Create services

--- a/src/main/scala/com/foursquare/exceptionator/util/ReservoirSampler.scala
+++ b/src/main/scala/com/foursquare/exceptionator/util/ReservoirSampler.scala
@@ -1,0 +1,91 @@
+// Copyright 2015 Foursquare Labs Inc. All Rights Reserved.
+
+package com.foursquare.exceptionator.util
+
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
+import scala.util.Random
+
+
+/**
+  * Samples size objects of type T uniformly
+  * See: http://en.wikipedia.org/wiki/Reservoir_sampling
+  *
+  * This is a threadsafe version of a reservoir sampler that exposes an
+  * interface in it's companion object for merging two samplers together in a
+  * way that preserves the probabilistic properties of a reservoir sampler.
+  */
+class ReservoirSampler[T: ClassTag](val size: Int) {
+  private val random = new Random()
+  private val reservoir = new ArrayBuffer[T](size)
+  private[ReservoirSampler] var numSampled = 0
+
+  def update(x: T): Unit = this.synchronized {
+    if (numSampled < size) {
+      reservoir.append(x)
+    } else {
+      val i = random.nextInt(numSampled)
+      if (i < reservoir.length) {
+        reservoir.update(i, x)
+      }
+    }
+    numSampled += 1
+  }
+
+  def sampled: Int = numSampled
+  def samples: Array[T] = this.synchronized(reservoir.toArray)
+  def state: ReservoirSampler.State[T] = this.synchronized(ReservoirSampler.State(samples, sampled))
+
+  def copy: ReservoirSampler[T] = ReservoirSampler(size, state)
+}
+
+object ReservoirSampler {
+  case class State[T](samples: Seq[T], sampled: Int)
+
+  def apply[T: ClassTag](size: Int, state: ReservoirSampler.State[T]): ReservoirSampler[T] = {
+    val sampler = new ReservoirSampler[T](size)
+    state.samples.foreach(sampler.update(_))
+    sampler.numSampled = state.sampled
+    sampler
+  }
+
+  private def mergeNotFull[T](
+    maybeFull: ReservoirSampler[T],
+    notFull: ReservoirSampler[T]
+  ): ReservoirSampler[T] = {
+    val merged = maybeFull.copy
+    notFull.samples.foreach(merged.update(_))
+    merged
+  }
+
+  /** Claim: This preserves the probabilistic properties of a reservoir sampler.
+    * The math works out, try it! */
+  def merge[T: ClassTag](r1: ReservoirSampler[T], r2: ReservoirSampler[T]): ReservoirSampler[T] = {
+    val size = if (r1.size != r2.size) {
+      throw new IllegalArgumentException("Can only merge reservoirs of the same size")
+    } else r1.size
+
+    val State(r1Samples, r1Sampled) = r1.state
+    val State(r2Samples, r2Sampled) = r2.state
+
+    if (r1Sampled >= size && r2Sampled >= size) {
+      val (fromR1, fromR2) = {
+        val r1Ratio = r1Sampled.toDouble / (r1Sampled+r2Sampled)
+        val r1ExactNum = r1Ratio * size
+        val r1Remainder = r1ExactNum - r1ExactNum.toInt
+        val r1Extra = if (Random.nextDouble < r1Remainder) 1 else 0
+        val r1Num = r1ExactNum.toInt + r1Extra
+        (r1Num, size - r1Num)
+      }
+      val r1Take = Random.shuffle(r1Samples.iterator).take(fromR1)
+      val r2Take = Random.shuffle(r2Samples.iterator).take(fromR2)
+      val mergedState = State((r1Take++r2Take).toSeq, r1Sampled+r2Sampled)
+      println(s"merging- r1Samples.size: ${r1Samples.size}, r1.size: ${r1.size}, r1Sampled: ${r1Sampled}, mergedState.samples.size: ${mergedState.samples.size}, mergedState.sampled: ${mergedState.sampled}")
+      ReservoirSampler(size, mergedState)
+    } else if (r1Sampled >= size) {
+      mergeNotFull(r1, r2)
+    } else {
+      mergeNotFull(r2, r1)
+    }
+  }
+}

--- a/src/main/scala/com/foursquare/exceptionator/util/ReservoirSampler.scala
+++ b/src/main/scala/com/foursquare/exceptionator/util/ReservoirSampler.scala
@@ -80,7 +80,6 @@ object ReservoirSampler {
       val r1Take = Random.shuffle(r1Samples.iterator).take(fromR1)
       val r2Take = Random.shuffle(r2Samples.iterator).take(fromR2)
       val mergedState = State((r1Take++r2Take).toSeq, r1Sampled+r2Sampled)
-      println(s"merging- r1Samples.size: ${r1Samples.size}, r1.size: ${r1.size}, r1Sampled: ${r1Sampled}, mergedState.samples.size: ${mergedState.samples.size}, mergedState.sampled: ${mergedState.sampled}")
       ReservoirSampler(size, mergedState)
     } else if (r1Sampled >= size) {
       mergeNotFull(r1, r2)

--- a/tester.py
+++ b/tester.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
   if len(args) != 2:
     print parser.print_usage()
     sys.exit(1)
-  
+
   connection = httplib.HTTPConnection('localhost:8080')
 
   sleep = 0
@@ -61,7 +61,7 @@ if __name__ == '__main__':
   try:
     fh = open(args[1])
     i = 0
-    
+
     for l in fh:
       i += 1
       if i < skip:
@@ -85,14 +85,16 @@ if __name__ == '__main__':
           buf.append(l)
 
       else:
-        buf.append(l)
+        o = json.loads(l)
+        o['id'] = i
+        buf.append(json.dumps(o))
 
       if (i % every) == 0:
         if options.multi:
           notice = '[%s]' % ','.join(buf)
         else:
           notice = buf[0]
-        times.append(post(connection, notice, options.multi)) 
+        times.append(post(connection, notice, options.multi))
         buf = []
 
   except KeyboardInterrupt:


### PR DESCRIPTION
Uses in-memory reservoir sampling to take a uniform sample of incoming NoticeRecords and store these in a new history collection (which should be a [capped collection](http://docs.mongodb.org/manual/core/capped-collections/)). The sample window, samples per window, and time between flushing are all configurable via `config.json`.

Realtime playback of sampled history data is available in the web UI by navigating to /history/_timestamp_. This is accessible by clicking on any exception graph to jump back in time to the timestamp at the click location.

Support is planned for per-bucket history playback; as is only playback of `all:all` is supported.
