### PR TITLE
implement per-bucket history view

### DIFF
--- a/src/main/scala/com/foursquare/exceptionator/actions/BucketActions.scala
+++ b/src/main/scala/com/foursquare/exceptionator/actions/BucketActions.scala
@@ -2,6 +2,7 @@
 
 package com.foursquare.exceptionator.actions
 
+import com.foursquare.exceptionator.model.BucketRecordHistogram
 import com.foursquare.exceptionator.model.io.{BucketId, Incoming, Outgoing}
 import org.bson.types.ObjectId
 import org.joda.time.DateTime
@@ -15,6 +16,12 @@ case class SaveResult(bucket: BucketId, oldResult: Option[BucketId], noticesToRe
 trait BucketActions extends IndexActions {
   def get(ids: List[String], noticesPerBucketLimit: Option[Int], now: DateTime): List[Outgoing]
   def get(name: String, key: String, now: DateTime): List[Outgoing]
+  def getHistograms(
+    ids: List[String],
+    now: DateTime,
+    includeMonth: Boolean,
+    includeDay: Boolean,
+    includeHour: Boolean): List[BucketRecordHistogram]
   def recentKeys(name: String, limit: Option[Int]): List[String]
   def lastHourHistogram(id: BucketId, now: DateTime): List[Int]
   def save(incomingId: ObjectId, incoming: Incoming, bucket: BucketId, maxRecent: Int): SaveResult

--- a/src/main/scala/com/foursquare/exceptionator/actions/HistoryActions.scala
+++ b/src/main/scala/com/foursquare/exceptionator/actions/HistoryActions.scala
@@ -2,8 +2,8 @@
 
 package com.foursquare.exceptionator.actions
 
-import com.foursquare.exceptionator.model.NoticeRecord
-import com.foursquare.exceptionator.model.io.Outgoing
+import com.foursquare.exceptionator.model.{BucketRecord, NoticeRecord}
+import com.foursquare.exceptionator.model.io.{BucketId, Outgoing}
 import org.joda.time.DateTime
 
 
@@ -12,6 +12,11 @@ trait HasHistoryActions {
 }
 
 trait HistoryActions extends IndexActions {
-  def get(time: DateTime, limit: Int): List[Outgoing]
+  def get(bucketName: String, time: DateTime, limit: Int): List[Outgoing]
+  def get(bucketName: String, bucketKey: String, time: DateTime, limit: Int): List[Outgoing]
+  def get(ids: List[String], time: DateTime, limit: Int): List[Outgoing]
+  def getGroupNotices(name: String, time: DateTime, limit: Int): List[NoticeRecord]
+  def getNotices(buckets: List[String], time: DateTime, limit: Int): List[NoticeRecord]
+  def oldestId: Option[DateTime]
   def save(notice: NoticeRecord): DateTime
 }

--- a/src/main/scala/com/foursquare/exceptionator/actions/concrete/ConcreteBucketActions.scala
+++ b/src/main/scala/com/foursquare/exceptionator/actions/concrete/ConcreteBucketActions.scala
@@ -181,7 +181,7 @@ class ConcreteBucketActions extends BucketActions with IndexActions with Logger 
       noticesToRemove)
   }
 
-  def deleteOldHistograms(time: Long, doIt: Boolean = true) {
+  def deleteOldHistograms(time: Long, doIt: Boolean = true): Unit = {
     val dateTime = new DateTime(time)
     val oldMonth = dateTime.minusMonths(2)
     val oldDay = dateTime.minusDays(2)

--- a/src/main/scala/com/foursquare/exceptionator/actions/concrete/ConcreteHistoryActions.scala
+++ b/src/main/scala/com/foursquare/exceptionator/actions/concrete/ConcreteHistoryActions.scala
@@ -2,9 +2,9 @@
 
 package com.foursquare.exceptionator.actions.concrete
 
-import com.foursquare.exceptionator.actions.{HistoryActions, IndexActions}
-import com.foursquare.exceptionator.model.{HistoryRecord, MongoOutgoing, NoticeRecord}
-import com.foursquare.exceptionator.model.io.Outgoing
+import com.foursquare.exceptionator.actions.{HasBucketActions, HistoryActions, IndexActions}
+import com.foursquare.exceptionator.model.{BucketRecord, HistoryRecord, MongoOutgoing, NoticeRecord}
+import com.foursquare.exceptionator.model.io.{BucketId, Outgoing}
 import com.foursquare.exceptionator.util.{Config, Logger, ReservoirSampler}
 import com.foursquare.rogue.lift.LiftRogue._
 import com.twitter.conversions.time._
@@ -18,7 +18,7 @@ import scala.language.postfixOps
 import scala.util.Random
 
 
-class ConcreteHistoryActions extends HistoryActions with IndexActions with Logger {
+class ConcreteHistoryActions(services: HasBucketActions) extends HistoryActions with IndexActions with Logger {
   val flushPeriod = Config.opt(_.getInt("history.flushPeriod")).getOrElse(60)
   val sampleRate = Config.opt(_.getInt("history.sampleRate")).getOrElse(50)
   val samplers = (new ConcurrentHashMap[DateTime, ReservoirSampler[NoticeRecord]]).asScala
@@ -57,47 +57,105 @@ class ConcreteHistoryActions extends HistoryActions with IndexActions with Logge
             val merged = ReservoirSampler.merge(existingSampler, sampler)
             val state = merged.state
             val sorted = state.samples.sortBy(_.id.value).reverse
-            existing.notices(sorted.toList).totalSampled(state.sampled).save
+            val buckets = sorted.flatMap(_.buckets.value).distinct
+            existing
+              .notices(sorted.toList)
+              .buckets(buckets.toList)
+              .totalSampled(state.sampled)
+              .save
           }
         }).getOrElse {
           logger.debug(s"Writing new history for ${historyId}")
           Stats.time("historyActions.flushNew") {
             val state = sampler.state
             val sorted = state.samples.sortBy(_.id.value).reverse
+            val buckets = sorted.flatMap(_.buckets.value).distinct
             HistoryRecord.createRecord
               .id(historyId)
               .notices(sorted.toList)
+              .buckets(buckets.toList)
               .sampleRate(sampleRate)
               .totalSampled(state.sampled)
               .save
           }
         }
-
-      HistoryRecord.histogramData.update(saved.id.value.getTime, saved.totalSampled.value)
-    }
-
-    // Delete any cached keys dropped from the capped history collection
-    for {
-      date <- HistoryRecord.select(_.id).orderAsc(_.id).get()
-      time <- HistoryRecord.histogramData.keys
-      if time < date.getTime
-    } {
-      HistoryRecord.histogramData.remove(time)
     }
   }
 
-  def get(time: DateTime, limit: Int): List[Outgoing] = {
+  def get(bucketName: String, time: DateTime, limit: Int): List[Outgoing] = {
+    val notices = getGroupNotices(bucketName, time, limit)
+    val ids = notices.flatMap(_.buckets.value.filter(_.startsWith(bucketName + ":")))
+    processNotices(ids, notices, time)
+  }
+
+  def get(bucketName: String, bucketKey: String, time: DateTime, limit: Int): List[Outgoing] = {
+    get(List(BucketId(bucketName, bucketKey).toString), time, limit)
+  }
+
+  def get(ids: List[String], time: DateTime, limit: Int): List[Outgoing] = {
+    val notices = getNotices(ids, time, limit)
+    processNotices(ids, notices, time)
+  }
+
+  def getNotices(buckets: List[String], time: DateTime, limit: Int): List[NoticeRecord] = {
     val historyId = HistoryRecord.idForTime(time)
-    val historyOpt = HistoryRecord.where(_.id lte historyId).orderDesc(_.id).get()
+    val historyOpt = HistoryRecord
+      .where(_.buckets in buckets)
+      .and(_.id lte historyId)
+      .orderDesc(_.id)
+      .get()
+
     historyOpt.map { history =>
-      val outgoing = history.notices.value.dropWhile(_.createDateTime.isAfter(time)).take(limit).map(MongoOutgoing(_).addHistorygrams())
-      if (outgoing.size < limit) {
+      // use a view to avoid creating an intermediate collection at each step
+      val notices = history.notices.value.view
+        .dropWhile(_.createDateTime.isAfter(time))
+        .filter(_.buckets.value.exists(buckets.contains(_)))
+        .take(limit)
+        .toList
+      if (notices.size < limit) {
         // recurse and look at previous records to flush out our list
-        outgoing ++ get(history.id.dateTimeValue.minusMillis(1), limit - outgoing.size)
+        notices ++ getNotices(buckets, history.id.dateTimeValue.minusMillis(1), limit - notices.size)
       } else {
-        outgoing
+        notices
       }
     }.getOrElse(Nil)
+  }
+
+  def getGroupNotices(name: String, time: DateTime, limit: Int): List[NoticeRecord] = {
+    val historyId = HistoryRecord.idForTime(time)
+    val historyOpt = HistoryRecord
+      .where(_.buckets startsWith name + ":")
+      .and(_.id lte historyId)
+      .orderDesc(_.id)
+      .get()
+
+    historyOpt.map { history =>
+      // use a view to avoid creating an intermediate collection at each step
+      val notices = history.notices.value.view
+        .dropWhile(_.createDateTime.isAfter(time))
+        .filter(_.buckets.value.exists(_.startsWith(name + ":")))
+        .take(limit)
+        .toList
+      if (notices.size < limit) {
+        // recurse and look at previous records to flush out our list
+        notices ++ getGroupNotices(name, history.id.dateTimeValue.minusMillis(1), limit - notices.size)
+      } else {
+        notices
+      }
+    }.getOrElse(Nil)
+  }
+
+  def oldestId: Option[DateTime] = HistoryRecord.select(_.id).orderAsc(_.id).get().map(new DateTime(_))
+
+  def processNotices(ids: List[String], notices: List[NoticeRecord], time: DateTime): List[Outgoing] = {
+    val buckets = BucketRecord.where(_._id in ids).fetch
+    val histograms = services.bucketActions.getHistograms(ids, time, true, true, true)
+    notices.map(n => {
+      val nbSet = n.buckets.value.toSet
+      val noticeBuckets = buckets.filter(b => nbSet(b.id))
+      val noticeBucketRecordHistograms = histograms.filter(h => nbSet(h.bucket))
+      MongoOutgoing(n).addBuckets(noticeBuckets, noticeBucketRecordHistograms, time)
+    })
   }
 
   // Save a notice to its HistoryRecord, using reservoir sampling

--- a/src/main/scala/com/foursquare/exceptionator/actions/concrete/ConcreteIncomingActions.scala
+++ b/src/main/scala/com/foursquare/exceptionator/actions/concrete/ConcreteIncomingActions.scala
@@ -55,7 +55,8 @@ class ConcreteIncomingActions(services: HasBucketActions with HasHistoryActions 
   }
 
   def doMaintenance(now: Long) {
-    services.bucketActions.deleteOldHistograms(now, true)
+    val histogramOldTime = services.historyActions.oldestId.map(_.getMillis).getOrElse(now)
+    services.bucketActions.deleteOldHistograms(histogramOldTime, true)
 
     // Find really stale buckets that haven't been updated for 60 days. And delete them
     Stats.time("incomingActions.deleteOldBuckets") {

--- a/src/main/scala/com/foursquare/exceptionator/service/ExceptionatorService.scala
+++ b/src/main/scala/com/foursquare/exceptionator/service/ExceptionatorService.scala
@@ -141,7 +141,7 @@ object ExceptionatorServer extends Logger {
         with HasPluginLoaderService
         with HasUserFilterActions {
       lazy val bucketActions = new ConcreteBucketActions
-      lazy val historyActions = new ConcreteHistoryActions
+      lazy val historyActions = new ConcreteHistoryActions(this)
       lazy val noticeActions = new ConcreteNoticeActions
       lazy val pluginLoader = new ConcretePluginLoaderService(this)
       lazy val userFilterActions = new ConcreteUserFilterActions


### PR DESCRIPTION
This commit includes a refactor of history functionality to support
bucket/bucket groups and rip out the existing history view code in
favor of using the same histogram system as realtime notices. This
makes history feature complete with the realtime notices view.

Note this also adds a new buckets field on the HistoryRecord, and
a corresponding (buckets, id) index. Existing history data should
backfill this field to maintain performance with this version.
